### PR TITLE
Get only the first container on node to call command

### DIFF
--- a/dockerserviceexec
+++ b/dockerserviceexec
@@ -39,6 +39,11 @@ fi
 if PAIR=$(dockernodeps $SERVICE) ; then
   NODE=${PAIR%%:*}
   CONTAINER=${PAIR#*:}
+  #this sequence takes the first container in case there are more of one in the node
+  set -f IFS=' '
+  set -- $CONTAINER
+  CONTAINER=$1
+  set +f; unset IFS
 else
   exit 1
 fi


### PR DESCRIPTION
We've been using your extremely useful helpers for a year (thanks!) and just found a small issue. When there are multiple replicas of the same service in the same node the command fails because it tries to invoke it with both container names and takes the second one as the parameter.
Example:
- dockernodeps my_service ->  node1: er234dse325 sdr234wsf3
- dockerserviceexec my_service  my_command ->  ssh -t node1 docker exec -it er234dse325 sdr234wsf3 my_command (and then it fails)

My proposal is to slice PAIR string to catch only the first container. I did it in a roughly way (despite it works) because I don't know too much about parameter expansion but probably it could be done in a more elegant way.